### PR TITLE
Revert "Bump black from 21.12b0 to 22.10.0"

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,5 +1,5 @@
 autopep8
-black==22.10.0
+black==21.12b0
 coverage==6.5.0
 Django==4.1.3
 django-crispy-forms==1.14.0


### PR DESCRIPTION
Reverts Nebucatnetzer/network_inventory#90

Currently mach-nix doesn't work with the latest black version.
https://github.com/DavHau/mach-nix/issues/521